### PR TITLE
implement checking that dates are sufficiently recent

### DIFF
--- a/main.go
+++ b/main.go
@@ -226,7 +226,7 @@ func handlePost(res http.ResponseWriter, req *http.Request) {
 	date, _ := time.ParseInLocation("2006-01-02", dateStr, loc)
 	date = date.Add(20*time.Hour)
 	if now.After(date) && date != locatedNullDate {
-		writeError(400, res, "We usually don't hold talks in the past.")
+		writeError(400, res, "Date of talk is set in the past. We usually don't hold talks in the past.")
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -26,7 +26,6 @@ var (
 	hook    = flag.String("hook", "", "A hook to run on every change")
 
 	loc  *time.Location
-	locatedNullDate time.Time
 	tpl  *template.Template
 	idRe = regexp.MustCompile(`^\d*$`)
 )
@@ -222,10 +221,8 @@ func handlePost(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	now := time.Now()
 	date, _ := time.ParseInLocation("2006-01-02", dateStr, loc)
-	date = date.Add(20*time.Hour)
-	if now.After(date) && date != locatedNullDate {
+	if time.Now().Sub(date) > 20*time.Hour && !date.IsZero() {
 		writeError(400, res, "Date of talk is set in the past. We usually don't hold talks in the past.")
 		return
 	}
@@ -322,8 +319,6 @@ func main() {
 	if err != nil {
 		log.Fatal("Could not load timezone-data:", err)
 	}
-	locatedNullDate, _ := time.ParseInLocation("2006-01-02", "", loc)
-	locatedNullDate = locatedNullDate.Add(20*time.Hour)
 
 	tpl, err = template.New("").Delims("<<", ">>").ParseFiles(*gettpl)
 	if err != nil {


### PR DESCRIPTION
this code checks whether an added talk is actually set in the future, if a date is supplied, to avoid placing talks in the past (be it intentionally or, more likely, by typo or mistake).
